### PR TITLE
fix: update the usage to display and copy the URL only for tools

### DIFF
--- a/src/pages/[...slug].vue
+++ b/src/pages/[...slug].vue
@@ -26,7 +26,7 @@ const loading = ref(true)
 const slug = route.params.slug as string[]
 const header = slug[slug.length - 1]
 const path = slug.join('/')
-const usage = `tools: ${ path }`
+const usage = `${ path }`
 const isSysTool = computed(() => slug.length === 1 && slug[0].startsWith('sys.'))
 
 let reference = path


### PR DESCRIPTION
With this change the page for a tool looks like this and the copy button copies just the URL.

<img width="1106" alt="Screenshot 2024-09-06 at 10 09 10 AM" src="https://github.com/user-attachments/assets/02f3a989-ba8c-4d66-815c-ff9c3e59120d">

Fixes https://github.com/gptscript-ai/desktop/issues/442